### PR TITLE
show git info with -v #50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test/verypush
 src/libsdb.so*
 src/sdb
 src/sdb-version.h
+src/sdb-version.c
 memcache/cmds
 memcache/cmds.h
 memcache/mcsdbc

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VAPIDIR=$(PFX)/share/vala/vapi/
 MANDIR=${PFX}/share/man/man1
 MKDIR=mkdir
 
-all: pkgconfig src/sdb-version.h
+all: pkgconfig src/sdb-version.h src/sdb-version.c
 	${MAKE} -C src
 	${MAKE} -C memcache
 ifneq (${HAVE_VALA},)
@@ -29,6 +29,16 @@ pkgconfig:
 
 src/sdb-version.h:
 	echo '#define SDB_VERSION "${SDBVER}"' > src/sdb-version.h
+	echo 'extern const char *SDB_GITTIP;' >> src/sdb-version.h
+	echo 'extern const char *SDB_GITTAP;' >> src/sdb-version.h
+	echo 'extern const char *SDB_BIRTH;' >> src/sdb-version.h
+	echo 'extern const int SDB_VERSION_COMMIT;' >> src/sdb-version.h
+
+src/sdb-version.c: .git/HEAD .git/index
+	echo 'const char *SDB_GITTIP = "$(shell git rev-parse HEAD 2>/dev/null)";' > src/sdb-version.c
+	echo 'const char *SDB_GITTAP = "$(shell git describe --tags 2>/dev/null)";' >> src/sdb-version.c
+	echo 'const char *SDB_BIRTH = "$(shell date +%Y-%m-%d)";' >> src/sdb-version.c
+	echo 'const int SDB_VERSION_COMMIT = $(shell git rev-list --all | wc -l);' >> src/sdb-version.c
 
 CFILES=cdb.c buffer.c cdb_make.c ls.c ht.c sdb.c num.c base64.c
 CFILES+=json.c ns.c lock.c util.c disk.c query.c array.c fmt.c main.c
@@ -40,7 +50,7 @@ sdb.js: src/sdb-version.h
 #json/api.c json/js0n.c json/json.c json/rangstr.c
 
 clean:
-	rm -f src/sdb-version.h
+	rm -f src/sdb-version.h src/sdb-version.c
 	cd src && ${MAKE} clean
 	cd memcache && ${MAKE} clean
 	cd test && ${MAKE} clean

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,10 @@ src/sdb-version.h:
 src/sdb-version.c: .git/HEAD .git/index
 	echo 'const char *SDB_GITTIP = "$(shell git rev-parse HEAD 2>/dev/null)";' > src/sdb-version.c
 	echo 'const char *SDB_GITTAP = "$(shell git describe --tags 2>/dev/null)";' >> src/sdb-version.c
-	echo 'const char *SDB_BIRTH = "$(shell date +%Y-%m-%d)";' >> src/sdb-version.c
 	echo 'const int SDB_VERSION_COMMIT = $(shell git rev-list --all | wc -l);' >> src/sdb-version.c
+	echo 'const char *SDB_BIRTH = "$(shell date +%Y-%m-%d)";' >> src/sdb-version.c
+
+.INTERMEDIATE: .git/HEAD .git/index
 
 CFILES=cdb.c buffer.c cdb_make.c ls.c ht.c sdb.c num.c base64.c
 CFILES+=json.c ns.c lock.c util.c disk.c query.c array.c fmt.c main.c
@@ -50,7 +52,7 @@ sdb.js: src/sdb-version.h
 #json/api.c json/js0n.c json/json.c json/rangstr.c
 
 clean:
-	rm -f src/sdb-version.h src/sdb-version.c
+	rm -f src/sdb-version.h
 	cd src && ${MAKE} clean
 	cd memcache && ${MAKE} clean
 	cd test && ${MAKE} clean
@@ -62,6 +64,8 @@ dist:
 	rm -f sdb-${SDBVER}.tar.gz
 	rm -rf sdb-${SDBVER}
 	git clone . sdb-${SDBVER}
+	cd sdb-${SDBVER} && ${MAKE} src/sdb-version.h
+	cd sdb-${SDBVER} && ${MAKE} src/sdb-version.c
 	rm -rf sdb-${SDBVER}/.git*
 	tar czvf sdb-${SDBVER}.tar.gz sdb-${SDBVER}
 	pub sdb-${SDBVER}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ src/sdb-version.c: .git/HEAD .git/index
 
 .INTERMEDIATE: .git/HEAD .git/index
 
+.git/HEAD: ;
+.git/index: ;
+
 CFILES=cdb.c buffer.c cdb_make.c ls.c ht.c sdb.c num.c base64.c
 CFILES+=json.c ns.c lock.c util.c disk.c query.c array.c fmt.c main.c
 EMCCFLAGS=-O2 -s EXPORTED_FUNCTIONS="['_sdb_querys','_sdb_new0']"

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 DESTDIR?=
 PREFIX?=/usr
 
-SDBVER=0.9.4
+SDBVER=0.9.6
 
 INSTALL?=install
 

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 DESTDIR?=
 PREFIX?=/usr
 
-SDBVER=0.9.2
+SDBVER=0.9.4
 
 INSTALL?=install
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ install:
 sdb-version.h:
 	cd .. ; ${MAKE} src/sdb-version.h
 
-sdb-version.c: ../.git/HEAD ../.git/index
+sdb-version.c:
 	cd .. ; ${MAKE} src/sdb-version.c
 
 shared: sdb-version.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ include ../config.mk
 
 CFLAGS+= -g -ggdb
 OBJ=cdb.o buffer.o cdb_make.o ls.o ht.o sdb.o num.o base64.o
-OBJ+=json.o ns.o lock.o util.o disk.o query.o array.o fmt.o
+OBJ+=json.o ns.o lock.o util.o disk.o query.o array.o fmt.o sdb-version.o
 
 SOBJ=$(subst .o,._o,${OBJ})
 
@@ -21,6 +21,9 @@ install:
 
 sdb-version.h:
 	cd .. ; ${MAKE} src/sdb-version.h
+
+sdb-version.c: ../.git/HEAD ../.git/index
+	cd .. ; ${MAKE} src/sdb-version.c
 
 shared: sdb-version.h
 	${MAKE} libsdb.${SOVER}

--- a/src/main.c
+++ b/src/main.c
@@ -159,7 +159,8 @@ static void showusage(int o) {
 }
 
 static void showversion(void) {
-	printf ("sdb "SDB_VERSION"\n");
+	printf ("sdb "SDB_VERSION" %d git.%s\ncommit: %s build: %s\n",
+			SDB_VERSION_COMMIT, SDB_GITTAP, SDB_GITTIP, SDB_BIRTH);
 	exit (0);
 }
 


### PR DESCRIPTION
    $ sdb -v
    sdb 0.9.4 603 git.0.9.4-11-gfbe5270
    commit: fbe527012f521131b6ee722c325b540e0ce7f4d0 build: 2015-03-30

didn't define values in sdb-version.h to avoid having to recompile everything in src after commit.