### PR TITLE
Add sdb_get_len()

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -334,15 +334,7 @@ SDB_API int sdb_array_size(Sdb *s, const char *key) {
 
 // NOTE: ignore empty buckets
 SDB_API int sdb_array_length(Sdb *s, const char *key) {
-	int ret = 0;
-	char *val = sdb_get (s, key, 0);
-	if (val && *val) {
-		// TOO SLOW
-		sdb_array_compact (val);
-		ret = sdb_alen (val);
-	}
-	free (val);
-	return ret;
+	return sdb_alen_ignore_empty (sdb_const_get (s, key, 0));
 }
 
 SDB_API int sdb_array_push_num(Sdb *s, const char *key, ut64 num, ut32 cas) {

--- a/src/json.c
+++ b/src/json.c
@@ -84,14 +84,15 @@ SDB_API int sdb_json_unset (Sdb *s, const char *k, const char *p, ut32 cas) {
 SDB_API int sdb_json_set (Sdb *s, const char *k, const char *p, const char *v, ut32 cas) {
 	const char *beg[3];
 	const char *end[3];
-	int l, idx, len[3];
-	char *b, *js, *str = NULL;
+	int jslen, l, idx, len[3];
+	char *b, *str = NULL;
+	const char *js;
 	Rangstr rs;
 	ut32 c;
 
 	if (!s || !k)
 		return 0;
-	js = sdb_get (s, k, &c);
+	js = sdb_const_get_len (s, k, &jslen, &c);
 	if (!js) {
 		b = malloc (strlen (p)+strlen (v)+8);
 		if (b) {
@@ -110,12 +111,11 @@ SDB_API int sdb_json_set (Sdb *s, const char *k, const char *p, const char *v, u
 		return 0;
 	}
 	if (cas && c != cas) {
-		free (js);
 		return 0;
 	}
 	rs = json_get (js, p);
 	if (!rs.p) {
-		char *b = malloc (strlen (js)+strlen(k)+strlen (v)+32);
+		char *b = malloc (jslen+strlen(k)+strlen (v)+32);
 		if (b) {
 			int curlen, is_str = isstring (v);
 			const char *q = is_str?"\"":"";
@@ -127,11 +127,9 @@ SDB_API int sdb_json_set (Sdb *s, const char *k, const char *p, const char *v, u
 			strcpy (b+curlen, js+1);
 			// transfer ownership
 			sdb_set_owned (s, k, b, cas);
-			free (js);
 			return 1;
 		}
 		// invalid json?
-		free (js);
 		return 0;
 	} 
 #define WLEN(x) (int)(size_t)(end[x]-beg[x])
@@ -147,7 +145,7 @@ SDB_API int sdb_json_set (Sdb *s, const char *k, const char *p, const char *v, u
 	}
 
 	beg[2] = rs.p + rs.t;
-	end[2] = js + strlen (js);
+	end[2] = js + jslen;
 	len[2] = WLEN (2);
 
 	// TODO: accelerate with small buffer in stack for small jsons
@@ -209,7 +207,6 @@ SDB_API int sdb_json_set (Sdb *s, const char *k, const char *p, const char *v, u
 		str[len[0]+len[2]] = 0;
 	}
 	sdb_set_owned (s, k, str, cas);
-	free (js);
 	return 1;
 }
 

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -195,7 +195,7 @@ SDB_API const char *sdb_const_get (Sdb* s, const char *key, ut32 *cas) {
 
 // TODO: add sdb_getf?
 
-SDB_API char *sdb_get (Sdb* s, const char *key, /*OUT*/ut32 *cas) {
+SDB_API char *sdb_get_len (Sdb* s, const char *key, int *vlen, ut32 *cas) {
 	ut32 hash, pos, len, keylen;
 	ut64 now = 0LL;
 	SdbKv *kv;
@@ -218,6 +218,7 @@ SDB_API char *sdb_get (Sdb* s, const char *key, /*OUT*/ut32 *cas) {
 				}
 			}
 			if (cas) *cas = kv->cas;
+			if (vlen) *vlen = kv->value_len;
 			return strdup (kv->value);
 		}
 		return NULL;
@@ -231,12 +232,18 @@ SDB_API char *sdb_get (Sdb* s, const char *key, /*OUT*/ut32 *cas) {
 		return NULL;
 	if ((len = cdb_datalen (&s->db))<1)
 		return NULL;
+	if (vlen)
+		*vlen = len;
 	if (!(buf = malloc (len+1))) // XXX too many mallocs
 		return NULL;
 	pos = cdb_datapos (&s->db);
 	cdb_read (&s->db, buf, len, pos);
 	buf[len] = 0;
 	return buf;
+}
+
+SDB_API char *sdb_get (Sdb* s, const char *key, ut32 *cas) {
+	return sdb_get_len (s, key, NULL, cas);
 }
 
 SDB_API int sdb_unset (Sdb* s, const char *key, ut32 cas) {
@@ -247,8 +254,8 @@ SDB_API int sdb_unset (Sdb* s, const char *key, ut32 cas) {
 SDB_API int sdb_uncat(Sdb *s, const char *key, const char *value, ut32 cas) {
 	// remove 'value' from current key value.
 	// TODO: cas is ignored here
-	char *p, *v = sdb_get (s, key, NULL);
-	int vlen = strlen (value);
+	int vlen;
+	char *p, *v = sdb_get_len (s, key, &vlen, NULL);
 	int mod = 0;
 	while ((p = strstr (v, value))) {
 		memmove (p, p+vlen, strlen (p+vlen)+1);

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -105,6 +105,7 @@ int  sdb_exists (Sdb*, const char *key);
 int  sdb_unset (Sdb*, const char *key, ut32 cas);
 int  sdb_unset_matching(Sdb *s, const char *k);
 char *sdb_get (Sdb*, const char *key, ut32 *cas);
+char *sdb_get_len (Sdb*, const char *key, int *vlen, ut32 *cas);
 const char *sdb_const_get (Sdb*, const char *key, ut32 *cas);
 const char *sdb_const_get_len (Sdb* s, const char *key, int *vlen, ut32 *cas);
 int  sdb_set (Sdb*, const char *key, const char *data, ut32 cas);

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -213,6 +213,7 @@ int sdb_array_remove_num (Sdb* s, const char *key, ut64 val, ut32 cas);
 char *sdb_anext(char *str, char **next);
 const char *sdb_const_anext(const char *str, const char **next);
 int sdb_alen(const char *str);
+int sdb_alen_ignore_empty(const char *str);
 int sdb_array_size(Sdb* s, const char *key);
 int sdb_array_length(Sdb* s, const char *key);
 

--- a/src/util.c
+++ b/src/util.c
@@ -139,6 +139,22 @@ SDB_API int sdb_alen(const char *str) {
 	return len;
 }
 
+SDB_API int sdb_alen_ignore_empty(const char *str) {
+	int len = 1;
+	const char *n, *p = str;
+	if (!p || !*p) return 0;
+	while (*p == SDB_RS) p++;
+	for (len=0; ; ) {
+		n = strchr (p, SDB_RS);
+		if (!n) break;
+		p = n+1;
+		if (*(p) == SDB_RS) continue;
+		len++;
+	}
+	if (*p) len++;
+	return len;
+}
+
 SDB_API char *sdb_anext(char *str, char **next) {
 	char *nxt, *p = strchr (str, SDB_RS);
 	if (p) { *p = 0; nxt = p+1; } else nxt = NULL;


### PR DESCRIPTION
First part of the split pull request #67.

Added `sdb_get_len` and changed `sdb_uncat` to use it instead of `sdb_get` and `strlen`.
Changed `sdb_json_set` to use `sdb_const_get_len`.
Created new `sdb_alen_ignore_empty` for using instead of `sdb_get` and `sdb_array_compact` in `sdb_arry_length` (previous variant had unnecessary malloc and memmove, as the compact array itself was discarded).