### PR TITLE
Fix building for the MinGW

### DIFF
--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -1,5 +1,8 @@
 /* Public domain. */
 
+#if __WINDOWS__ && !__CYGWIN__
+#include <malloc.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
<malloc.h> is needed for _aligned_malloc() function on Windows.