### PR TITLE
Reduce CDB header size (2048 bytes -> 1024 bytes)

### DIFF
--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -147,10 +147,8 @@ int cdb_make_finish(struct cdb_make *c) {
 	}
 
 	for (i=0; i<256; i++) {
-		count = c->count[i];
-		len = count<<1; //(*2)
-		ut32_pack (c->final + 8 * i, c->pos);
-		ut32_pack (c->final + 8 * i + 4, len);
+		len = count = c->count[i];
+		ut32_pack (c->final + 4 * i, c->pos);
 
 		for (u=0; u<len; u++)
 			c->hash[u].h = c->hash[u].p = 0;

--- a/src/cdb_make.h
+++ b/src/cdb_make.h
@@ -18,7 +18,7 @@ struct cdb_hplist {
 
 struct cdb_make {
 	char bspace[8192];
-	char final[2048];
+	char final[1024];
 	ut32 count[256];
 	ut32 start[256];
 	struct cdb_hplist *head;

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -598,9 +598,10 @@ static int getbytes(Sdb *s, char *b, int len) {
 }
 
 SDB_API void sdb_dump_begin (Sdb* s) {
-	if (s->fd != -1)
-		seek_set (s->fd, (s->pos=2048));
-	else s->pos = 0;
+	if (s->fd != -1) {
+		s->pos = sizeof (((struct cdb_make *)0)->final);
+		seek_set (s->fd, s->pos);
+	} else s->pos = 0;
 }
 
 SDB_API SdbKv *sdb_dump_next (Sdb* s) {


### PR DESCRIPTION
The trick is to compute the subtable length n_i, 0 <= i <= 255, using
the subtable pointers p_i and p_{i+1}. Observe that

        n_i = (p_{i+1} - p_i) / L, where L is the slot length.

So let's not waste 1024 bytes of space to encode n_i.