### PR TITLE
MinGW: use _aligned_free() instead of free()

### DIFF
--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -45,7 +45,11 @@ char *cdb_alloc(ut32 n) {
 }
 
 void cdb_alloc_free(void *x) {
+#if __SDB_WINDOWS__ && !__CYGWIN__
+	_aligned_free(x);
+#else
 	free (x);
+#endif
 }
 #endif
 


### PR DESCRIPTION
As per Issue #75, for MinGW use _aligned_free() instead of free() for memory allocated with _aligned_malloc()