### PR TITLE
Improve ht.c's handling of removed entries

### DIFF
--- a/src/ht.c
+++ b/src/ht.c
@@ -44,8 +44,6 @@
  * free to avoid exponential performance degradation as the hash table fills
  */
 
-static ut32 deleted_data;
-
 static const struct {
 	ut32 max_entries, size, rehash;
 } hash_sizes[] = {
@@ -82,9 +80,10 @@ static const struct {
 	{ 2147483648ul,	2362232233ul,	2362232231ul}
 };
 
-#define entry_is_free(x) (!x || !x->data)
-#define entry_is_deleted(x) (!x || x->data == &deleted_data)
-#define entry_is_present(x) (x && x->data && x->data != &deleted_data)
+#define DELETED_HASH ((ut32)~0)
+#define entry_is_free(x) (!x->hash && !x->data)
+#define entry_is_deleted(x) (x->hash == DELETED_HASH && !x->data)
+#define entry_is_present(x) (x->data || (x->hash && x->hash != DELETED_HASH))
 
 /**
  * Finds a hash table entry with the given key and hash of that key.
@@ -233,7 +232,8 @@ void ht_delete_entry(SdbHash *ht, SdbHashEntry *entry) {
 		ls_delete (ht->list, entry->iter);
 		entry->iter = NULL;
 	}
-	entry->data = (void *) &deleted_data;
+	entry->hash = DELETED_HASH;
+	entry->data = NULL;
 	ht->entries--;
 	ht->deleted_entries++;
 }


### PR DESCRIPTION
I'd guess this improvement is also welcomed to this repo. This was already merged to r2 in order to fix a segfault that occurred as a result of careless use of hashtable entries (without specifically checking for deleted entries that should be treated as empty in spite of `entry->data != NULL`). See https://github.com/radare/radare2/pull/5252 for full explanation.