### PR TITLE
Correcting strcmp() in sdb_set_internal

### DIFF
--- a/test/cas.c
+++ b/test/cas.c
@@ -7,14 +7,24 @@ int main(int argc, char **argv) {
 	r = sdb_set (s, "hello", "world", 1);
 	sdb_const_get (s, "hello", &cas);
 	printf ("r%d = c%u\n", r, cas);
-	if (r != cas) printf ("error\n");
+	if (r != cas) {
+		printf ("error\n");
+		return 1;
+	}
 
 	r = sdb_set (s, "hello", "world", r);
 	sdb_const_get (s, "hello", &cas);
-	if (r != cas) printf ("error\n");
+	if (r != cas) {
+		printf ("error\n");
+		return 1;
+	}
 
 	printf ("r%d = c%u\n", r, cas);
-	if (r==0) printf ("failed\n");
+	if (r==0) {
+		printf ("failed\n");
+		return 1;
+	}
+
 	sdb_free (s);
 	return 0;
 }

--- a/test/cas.c
+++ b/test/cas.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	r = sdb_set (s, "hello", "world", r);
+	sdb_set (s, "hello", "world", r);
 	sdb_const_get (s, "hello", &cas);
 	if (r != cas) {
 		printf ("error\n");


### PR DESCRIPTION
After my misunderstanding in radare/radare2#5739, I've checked out sdb and noticed that [test/cas.c](https://github.com/radare/sdb/blob/master/test/cas.c) appears to fail on a fresh checkout. I am assuming the tests are correct and that the functionality of setting the same key twice should not fail.

Before:

    time ./cas
    r2 = c2
    error
    r0 = c2
    failed
            0.00 real         0.00 user         0.00 sys

After this change is applied:

    cc -o cas cas.c ../src/libsdb.a -I../../src -I ../src
    time ./cas
    r2 = c2
    r3 = c3
            0.00 real         0.00 user         0.00 sys