### PR TITLE
Fix value always equals to key issue

### DIFF
--- a/src/ht.c
+++ b/src/ht.c
@@ -30,7 +30,7 @@ const int ht_primes_sizes[] = {
 // keydup - function to duplicate to key (eg strdup), if NULL just does =.
 // valdup - same as keydup, but for values
 // pair_free - function for freeing a keyvaluepair - if NULL just does free.
-// calcsize - functino to calculate the size of a value. if NULL, just stores 0.
+// calcsize - function to calculate the size of a value. if NULL, just stores 0.
 SdbHash* internal_ht_new(ut32 size, HashFunction hashfunction, ListComparator comparator, DupKey keydup, DupValue valdup, HtKvFreeFunc pair_free, CalcSize calcsize) {
 	SdbHash* ht = calloc (1, sizeof (*ht));
 	if (!ht) {
@@ -148,7 +148,7 @@ static bool internal_ht_insert(SdbHash* ht, bool update, const char* key, const 
 			kvp->key = ht->dupkey
 				? ht->dupkey (key) : (char *)key;
 			kvp->value = ht->dupvalue
-				? ht->dupvalue (key) : (char *)value;
+				? ht->dupvalue (value) : (char *)value;
 			bucket = hash % ht->size;
 			kvp->expire = 0;
 			kvp->value_len = ht->calcsize
@@ -208,7 +208,8 @@ bool ht_insert_kvp(SdbHash* ht, SdbKv* kvp, bool update) {
 	return false;
 }
 
-// Looks up the corresponding value from the key. Returns true if found, false
+// Returns the corresponding SdbKv entry from the key.
+// If `found` is not NULL, it will be set to true if the entry was found, false
 // otherwise.
 SdbKv* ht_find_kvp(SdbHash* ht, const char* key, bool* found) {
 	ut32 hash;
@@ -222,14 +223,21 @@ SdbKv* ht_find_kvp(SdbHash* ht, const char* key, bool* found) {
 			? ht->cmp (key, kvp->key) == 0
 			: key == kvp->key;
 		if (match) {
-			*found = true;
+			if (found) {
+				*found = true;
+			}
 			return  kvp;
 		}
 	}
-	*found = false;
+	if (found) {
+		*found = false;
+	}
 	return NULL;
 }
 
+// Looks up the corresponding value from the key.
+// If `found` is not NULL, it will be set to true if the entry was found, false
+// otherwise.
 char* ht_find(SdbHash* ht, const char* key, bool* found) {
 	bool _found = false;
 	if (!found) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,7 @@ ALL=all
 all: $(BINS) $(SCRIPTS) reset
 	@suite/run.sh
 	-cd api && $(MAKE)
+	-cd unit && $(MAKE) run
 
 me:
 	$(MAKE) -C ../src

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,0 +1,16 @@
+OBJECTS = $(patsubst %.c,%,$(wildcard *.c))
+LDFLAGS += $(shell pkg-config --libs sdb)
+CFLAGS += $(shell pkg-config --cflags sdb) -g
+
+all: $(OBJECTS)
+
+run: all
+	./run.sh
+
+$(OBJECTS):%:%.c
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+clean:
+	rm -f $(OBJECTS)
+
+.PHONY: all run $(OBJECTS)

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -1,0 +1,132 @@
+// minunit.h comes from http://www.jera.com/techinfo/jtns/jtn002.html
+//
+// You may use the code in this tech note for any purpose,
+// with the understanding that it comes with NO WARRANTY.
+
+#ifndef TERMCOLOR_H
+#define TERMCOLOR_H
+
+#define TRED "\x1b[31m"
+#define TGREEN "\x1b[32m"
+#define TYELLOW "\x1b[33m"
+#define TBLUE "\x1b[34m"
+#define TMAGENTA "\x1b[35m"
+#define TCYAN "\x1b[36m"
+#define TBOLD "\x1b[1m"
+#define TRESET "\x1b[0m"
+#endif
+
+#define MU_PASSED 1
+#define MU_ERR 0
+
+#define MU_TEST_UNBROKEN 0
+#define MU_TEST_BROKEN 1
+
+#define mu_assert(message, test)                           \
+	do {                                               \
+		if (!(test)) {                             \
+			mu_fail(message);                  \
+			mu_test_status = MU_TEST_UNBROKEN; \
+		}                                          \
+	} while (0)
+
+#define mu_perror(message)                                                \
+	do {                                                              \
+		if (mu_test_status != MU_TEST_BROKEN) {                   \
+			printf(TBOLD TRED "ERR\nFail at line %d: " TRESET \
+					  "%s\n\n",                       \
+			       __LINE__, message);                        \
+		} else {                                                  \
+			printf(TBOLD TYELLOW "Broken at line %d: " TRESET \
+					     "%s\n\n",                    \
+			       __LINE__, message);                        \
+		}                                                         \
+	} while (0)
+
+#define mu_psyserror(message)       \
+	do {                        \
+		perror(message);    \
+		mu_perror(message); \
+	} while (0)
+
+#define mu_fail(message)                                             \
+	do {                                                         \
+		mu_perror(message);                                  \
+		if (mu_test_status != MU_TEST_BROKEN) return MU_ERR; \
+	} while (0)
+
+#define mu_ignore                               \
+	do {                                    \
+		printf(TYELLOW "IGN\n" TRESET); \
+		return MU_PASSED;               \
+	} while (0)
+
+#define mu_end                                \
+	do {                                  \
+		printf(TGREEN "OK\n" TRESET); \
+		return MU_PASSED;             \
+	} while (0)
+
+#define mu_cleanup_end                     \
+	do {                               \
+		if (retval == MU_PASSED) { \
+			mu_end;            \
+		} else {                   \
+			return retval;     \
+		}                          \
+	} while (0)
+
+#define mu_sysfail(message)       \
+	do {                      \
+		perror(message);  \
+		mu_fail(message); \
+	} while (0)
+
+#define mu_assert_eq(actual, expected, message)                       \
+	do {                                                          \
+		char _meqstr[2048];                                   \
+		sprintf(_meqstr, "%s: expected %d, got %d.", message, \
+			expected, actual);                            \
+		mu_assert(_meqstr, (expected) == (actual));           \
+	} while (0)
+
+#define mu_assert_neq(actual, expected, message)                          \
+	do {                                                              \
+		char _meqstr[2048];                                       \
+		sprintf(_meqstr, "%s: expected not %d, got %d.", message, \
+			expected, actual);                                \
+		mu_assert(_meqstr, (expected) != (actual));               \
+	} while (0)
+
+#define mu_assert_streq(actual, expected, message)                     \
+	do {                                                           \
+		char _meqstr[2048];                                    \
+		sprintf(_meqstr, "%s: expected %s, got %s.", message,  \
+			expected, actual);                             \
+		mu_assert(_meqstr, strcmp((expected), (actual)) == 0); \
+	} while (0)
+
+#define mu_run_test(test)                       \
+	do {                                    \
+		int result;                     \
+		printf(TBOLD #test TRESET " "); \
+		result = test();                \
+		tests_run++;                    \
+		tests_passed += result;         \
+	} while (0)
+
+#define mu_cleanup_fail(label, message) \
+	do {                            \
+		mu_perror(message);     \
+		retval = MU_ERR;        \
+		goto label;             \
+	} while (0)
+#define mu_cleanup_sysfail(label, message) \
+	do {                               \
+		mu_psyserror(message);     \
+		retval = MU_ERR;           \
+		goto label;                \
+	} while (0)
+int tests_run = 0;
+int tests_passed = 0;
+int mu_test_status = MU_TEST_UNBROKEN;

--- a/test/unit/run.sh
+++ b/test/unit/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# To run with kcov
+# export KCOV="kcov /path/to/output"
+# kcov output will be placed in the /path/to/output/index.html
+
+EXIT_STATUS=0
+for i in $(find . -name 'test_*' -type f -perm -111); do
+	filename=$(basename "$i")
+	echo "$filename"
+	${KCOV} $i
+	if [ "$?" -ne 0 ] ; then
+		EXIT_STATUS=1
+	fi
+done
+
+exit $EXIT_STATUS

--- a/test/unit/test_hash.c
+++ b/test/unit/test_hash.c
@@ -1,0 +1,25 @@
+#include "minunit.h"
+#include <sdb.h>
+
+bool test_ht_insert_lookup(void) {
+	SdbHash *ht = ht_new ();
+	ht_insert (ht, "AAAA", "vAAAA");
+	ht_insert (ht, "BBBB", "vBBBB");
+	ht_insert (ht, "CCCC", "vCCCC");
+
+	mu_assert_streq (ht_find (ht, "BBBB", NULL), "vBBBB", "BBBB value wrong");
+	mu_assert_streq (ht_find (ht, "AAAA", NULL), "vAAAA", "AAAA value wrong");
+	mu_assert_streq (ht_find (ht, "CCCC", NULL), "vCCCC", "CCCC value wrong");
+
+	ht_free (ht);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_ht_insert_lookup);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
I started adding some unit testing for SDB.... first test, and it looks like at the moment the whole thing should be completely broken :( :( Indeed key and value are always the same when inserted through `ht_hash_insert`. 

What I would like to do is to make this HT implementation a little bit more generic, so that we can use that in r2 easily for other needs and not only for string-string pairs.