### PR TITLE
Correct typo in src/util.c: USE_MONOTINIC_CLOCK -> USE_MONOTONIC_CLOCK

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -214,7 +214,7 @@ SDB_API const char *sdb_const_anext(const char *str, const char **next) {
 }
 
 SDB_API ut64 sdb_now () {
-#if USE_MONOTINIC_CLOCK
+#if USE_MONOTONIC_CLOCK
 	struct timespec ts;
 	if (!clock_gettime (CLOCK_MONOTONIC, &ts)) {
 		return ts.tv_sec;


### PR DESCRIPTION
Self-explanatory.

Pretty sure it's a typo...