### PR TITLE
Sdbkv refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,13 @@ test/syncget
 test/test.db
 test/unit/test_hash
 test/unit/test_hash.dSYM/
+test/.tmp
+test/api/array
+test/api/refs
+test/unit/.tmp
+test/unit/test_array
+test/unit/test_ls
+test/unit/test_sdb
 src/libsdb.so*
 src/sdb
 src/sdb_version.h

--- a/src/query.c
+++ b/src/query.c
@@ -335,8 +335,7 @@ next_quote:
 			SdbListIter *iter;
 			SdbKv *kv;
 			ls_foreach (list, iter, kv) {
-				//eprintf ("(%s)(%s)\n", kv->key, kv->value);
-				foreach_list_cb (&user, kv->key, kv->value);
+				foreach_list_cb (&user, SDBKV_KEY (kv), SDBKV_VALUE (kv));
 			}
 			ls_free (list);
 			goto fail;
@@ -376,9 +375,9 @@ next_quote:
 			SdbListIter *li;
 			SdbList *l = sdb_foreach_match (s, cmd + 2, false);
 			ls_foreach (l, li, kv) {
-				strbuf_append (out, kv->key, 0);
+				strbuf_append (out, SDBKV_KEY (kv), 0);
 				strbuf_append (out, "=", 0);
-				strbuf_append (out, kv->value, 1);
+				strbuf_append (out, SDBKV_VALUE (kv), 1);
 			}
 			fflush (stdout);
 			ls_free (l);

--- a/src/query.c
+++ b/src/query.c
@@ -335,7 +335,7 @@ next_quote:
 			SdbListIter *iter;
 			SdbKv *kv;
 			ls_foreach (list, iter, kv) {
-				foreach_list_cb (&user, SDBKV_KEY (kv), SDBKV_VALUE (kv));
+				foreach_list_cb (&user, sdbkv_key (kv), sdbkv_value (kv));
 			}
 			ls_free (list);
 			goto fail;
@@ -375,9 +375,9 @@ next_quote:
 			SdbListIter *li;
 			SdbList *l = sdb_foreach_match (s, cmd + 2, false);
 			ls_foreach (l, li, kv) {
-				strbuf_append (out, SDBKV_KEY (kv), 0);
+				strbuf_append (out, sdbkv_key (kv), 0);
 				strbuf_append (out, "=", 0);
-				strbuf_append (out, SDBKV_VALUE (kv), 1);
+				strbuf_append (out, sdbkv_value (kv), 1);
 			}
 			fflush (stdout);
 			ls_free (l);

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -91,7 +91,6 @@ SDB_API Sdb* sdb_new(const char *path, const char *name, int lock) {
 	}
 	s->ht = sdb_ht_new ();
 	s->lock = lock;
-	// s->ht->list->free = (SdbListFree)sdb_kv_free;
 	// if open fails ignore
 	if (global_hook) {
 		sdb_hook (s, global_hook, global_user);
@@ -184,7 +183,7 @@ static void sdb_fini(Sdb* s, int donull) {
 	}
 	free (s->ndump);
 	free (s->dir);
-	free (SDBKV_VALUE (&s->tmpkv));
+	free (sdbkv_value (&s->tmpkv));
 	s->tmpkv.value_len = 0;
 	if (donull) {
 		memset (s, 0, sizeof (Sdb));
@@ -226,7 +225,7 @@ SDB_API const char *sdb_const_get_len(Sdb* s, const char *key, int *vlen, ut32 *
 	/* search in memory */
 	kv = (SdbKv*) sdb_ht_find_kvp (s->ht, key, &found);
 	if (found) {
-		if (!SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
+		if (!sdbkv_value (kv) || !*sdbkv_value (kv)) {
 			return NULL;
 		}
 		if (s->timestamped && kv->expire) {
@@ -242,9 +241,9 @@ SDB_API const char *sdb_const_get_len(Sdb* s, const char *key, int *vlen, ut32 *
 			*cas = kv->cas;
 		}
 		if (vlen) {
-			*vlen = SDBKV_VALUE_LEN (kv);
+			*vlen = sdbkv_value_len (kv);
 		}
-		return SDBKV_VALUE (kv);
+		return sdbkv_value (kv);
 	}
 	/* search in disk */
 	if (s->fd == -1) {
@@ -354,7 +353,7 @@ SDB_API bool sdb_exists(Sdb* s, const char *key) {
 	}
 	kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
 	if (found && kv) {
-		return *SDBKV_VALUE (kv);
+		return *sdbkv_value (kv);
 	}
 	if (s->fd == -1) {
 		return false;
@@ -462,59 +461,19 @@ SDB_API bool sdb_kv_match(SdbKv *kv, const char *expr) {
 		char *e = strdup (expr);
 		char *ep = e + (eq - expr);
 		*ep++ = 0;
-		bool res = !*e || match (SDBKV_KEY (kv), e);
-		bool res2 = !*ep || match (SDBKV_VALUE (kv), ep);
+		bool res = !*e || match (sdbkv_key (kv), e);
+		bool res2 = !*ep || match (sdbkv_value (kv), ep);
 		free (e);
 		return res && res2;
 	}
-	return match (SDBKV_KEY (kv), expr);
+	return match (sdbkv_key (kv), expr);
 }
 
-SDB_API SdbKv* sdb_kv_new(const char *k, const char *v) {
-	return sdb_kv_new2 (k, strlen (k), v, strlen (v));
-#if 0
-	SdbKv *kv;
-	int vl;
-	if (v) {
-		vl = strlen (v);
-		if (vl >= SDB_VSZ) {
-			return NULL;
-		}
-	} else {
-		vl = 0;
-	}
-	kv = R_NEW0 (SdbKv);
-	kv->key_len = strlen (k);
-	if (key_len >= SDB_KSZ) {
-		free (kv);
-		return NULL;
-	}
-	kv->key = malloc (SDBKV_KEY_LEN (kv) + 1);
-	if (!SDBKV_KEY (kv)) {
-		free (kv);
-		return NULL;
-	}
-	memcpy (SDBKV_KEY (kv), k, SDBKV_KEY_LEN (kv) + 1);
-	kv->value_len = vl;
-	if (vl) {
-		kv->value = malloc (vl + 1);
-		if (!SDBKV_VALUE (kv)) {
-			free (SDBKV_KEY (kv));
-			free (kv);
-			return NULL;
-		}
-		memcpy (SDBKV_VALUE (kv), v, vl + 1);
-	} else {
-		kv->value = NULL;
-		kv->value_len = 0;
-	}
-	kv->cas = nextcas ();
-	kv->expire = 0LL;
-	return kv;
-#endif
+SDB_API SdbKv* sdbkv_new(const char *k, const char *v) {
+	return sdbkv_new2 (k, strlen (k), v, strlen (v));
 }
 
-SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl) {
+SDB_API SdbKv* sdbkv_new2(const char *k, int kl, const char *v, int vl) {
 	SdbKv *kv;
 	if (v) {
 		if (vl >= SDB_VSZ) {
@@ -528,21 +487,21 @@ SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl) {
 	}
 	kv = R_NEW0 (SdbKv);
 	kv->key_len = kl;
-	kv->key = malloc (SDBKV_KEY_LEN (kv) + 1);
-	if (!SDBKV_KEY (kv)) {
+	kv->key = malloc (sdbkv_key_len (kv) + 1);
+	if (!sdbkv_key (kv)) {
 		free (kv);
 		return NULL;
 	}
-	memcpy (SDBKV_KEY (kv), k, SDBKV_KEY_LEN (kv) + 1);
+	memcpy (sdbkv_key (kv), k, sdbkv_key_len (kv) + 1);
 	kv->value_len = vl;
 	if (vl) {
 		kv->value = malloc (vl + 1);
-		if (!SDBKV_VALUE (kv)) {
-			free (SDBKV_KEY (kv));
+		if (!sdbkv_value (kv)) {
+			free (sdbkv_key (kv));
 			free (kv);
 			return NULL;
 		}
-		memcpy (SDBKV_VALUE (kv), v, vl + 1);
+		memcpy (sdbkv_value (kv), v, vl + 1);
 	} else {
 		kv->value = NULL;
 		kv->value_len = 0;
@@ -552,9 +511,9 @@ SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl) {
 	return kv;
 }
 
-SDB_API void sdb_kv_free(SdbKv *kv) {
-	free (SDBKV_KEY (kv));
-	free (SDBKV_VALUE (kv));
+SDB_API void sdbkv_free(SdbKv *kv) {
+	free (sdbkv_key (kv));
+	free (sdbkv_value (kv));
 	R_FREE (kv);
 }
 
@@ -586,7 +545,7 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 	}
 	cdb_findstart (&s->db);
 	kv = sdb_ht_find_kvp (s->ht, key, &found);
-	if (found && SDBKV_VALUE (kv)) {
+	if (found && sdbkv_value (kv)) {
 		if (cdb_findnext (&s->db, sdb_hash (key), key, klen)) {
 			if (cas && kv->cas != cas) {
 				if (owned) {
@@ -594,21 +553,21 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 				}
 				return 0;
 			}
-			if (vlen == SDBKV_VALUE_LEN (kv) && !strcmp (SDBKV_VALUE (kv), val)) {
+			if (vlen == sdbkv_value_len (kv) && !strcmp (sdbkv_value (kv), val)) {
 				sdb_hook_call (s, key, val);
 				return kv->cas;
 			}
 			kv->cas = cas = nextcas ();
 			if (owned) {
 				kv->value_len = vlen;
-				free (SDBKV_VALUE (kv));
+				free (sdbkv_value (kv));
 				kv->value = val; // owned
 			} else {
-				if ((ut32)vlen > SDBKV_VALUE_LEN (kv)) {
-					free (SDBKV_VALUE (kv));
+				if ((ut32)vlen > sdbkv_value_len (kv)) {
+					free (sdbkv_value (kv));
 					kv->value = malloc (vlen + 1);
 				}
-				memcpy (SDBKV_VALUE (kv), val, vlen + 1);
+				memcpy (sdbkv_value (kv), val, vlen + 1);
 				kv->value_len = vlen;
 			}
 		} else {
@@ -620,13 +579,13 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 	// empty values are also stored
 	// TODO store only the ones that are in the CDB
 	if (owned) {
-		kv = sdb_kv_new2 (key, klen, NULL, 0);
+		kv = sdbkv_new2 (key, klen, NULL, 0);
 		if (kv) {
 			kv->value = val;
 			kv->value_len = vlen;
 		}
 	} else {
-		kv = sdb_kv_new2 (key, klen, val, vlen);
+		kv = sdbkv_new2 (key, klen, val, vlen);
 	}
 	if (kv) {
 		ut32 cas = kv->cas = nextcas ();
@@ -659,11 +618,11 @@ static int sdb_foreach_list_cb(void *user, const char *k, const char *v) {
 static int __cmp_asc(const void *a, const void *b) {
 	const SdbKv *ka = a;
 	const SdbKv *kb = b;
-	return strcmp (SDBKV_KEY (ka), SDBKV_KEY (kb));
+	return strcmp (sdbkv_key (ka), sdbkv_key (kb));
 }
 
 SDB_API SdbList *sdb_foreach_list(Sdb* s, bool sorted) {
-	SdbList *list = ls_newf ((SdbListFree)sdb_kv_free);
+	SdbList *list = ls_newf ((SdbListFree)sdbkv_free);
 	sdb_foreach (s, sdb_foreach_list_cb, list);
 	if (sorted) {
 		ls_sort (list, __cmp_asc);
@@ -693,7 +652,7 @@ static int sdb_foreach_match_cb(void *user, const char *k, const char *v) {
 }
 
 SDB_API SdbList *sdb_foreach_match(Sdb* s, const char *expr, bool single) {
-	SdbList *list = ls_newf ((SdbListFree)sdb_kv_free);
+	SdbList *list = ls_newf ((SdbListFree)sdbkv_free);
 	_match_sdb_user o = { expr, list, single };
 	sdb_foreach (s, sdb_foreach_match_cb, &o);
 #if 0
@@ -731,12 +690,12 @@ static bool sdb_foreach_cdb(Sdb *s, SdbForeachCallback cb,
 		SdbKv *kv = sdb_ht_find_kvp (s->ht, k, &found);
 		if (found) {
 			free (v);
-			if (kv && SDBKV_KEY (kv) && SDBKV_VALUE (kv)) {
-				if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
+			if (kv && sdbkv_key (kv) && sdbkv_value (kv)) {
+				if (!cb (user, sdbkv_key (kv), sdbkv_value (kv))) {
 					return false;
 				}
 				if (cb2) {
-					cb2 (user, k, SDBKV_VALUE (kv));
+					cb2 (user, k, sdbkv_value (kv));
 				}
 			}
 		} else {
@@ -764,10 +723,10 @@ SDB_API bool sdb_foreach(Sdb* s, SdbForeachCallback cb, void *user) {
 	}
 #if INSERTORDER
 	ls_foreach (s->ht->list, iter, kv) {
-		if (!kv || !SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
+		if (!kv || !sdbkv_value (kv) || !*sdbkv_value (kv)) {
 			continue;
 		}
-		if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
+		if (!cb (user, sdbkv_key (kv), sdbkv_value (kv))) {
 			return sdb_foreach_end (s, false);
 		}
 	}
@@ -775,10 +734,10 @@ SDB_API bool sdb_foreach(Sdb* s, SdbForeachCallback cb, void *user) {
 	ut32 i;
 	for (i = 0; i < s->ht->size; i++) {
 		ls_foreach (s->ht->table[i], iter, kv) {
-			if (!kv || !SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
+			if (!kv || !sdbkv_value (kv) || !*sdbkv_value (kv)) {
 				continue;
 			}
-			if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
+			if (!cb (user, sdbkv_key (kv), sdbkv_value (kv))) {
 				return sdb_foreach_end (s, false);
 			}
 		}
@@ -821,10 +780,10 @@ SDB_API bool sdb_sync(Sdb* s) {
 	/* append new keyvalues */
 	for (i = 0; i < s->ht->size; ++i) {
 		ls_foreach (s->ht->table[i], iter, kv) {
-			if (SDBKV_KEY (kv) && SDBKV_VALUE (kv) && *SDBKV_VALUE (kv) && !kv->expire) {
-				if (sdb_disk_insert (s, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
+			if (sdbkv_key (kv) && sdbkv_value (kv) && *sdbkv_value (kv) && !kv->expire) {
+				if (sdb_disk_insert (s, sdbkv_key (kv), sdbkv_value (kv))) {
 					it.n = iter->n;
-					sdb_remove (s, SDBKV_KEY (kv), 0);
+					sdb_remove (s, sdbkv_key (kv), 0);
 					iter = &it;
 				}
 			}
@@ -854,9 +813,9 @@ SDB_API SdbKv *sdb_dump_next(Sdb* s) {
 		return NULL;
 	}
 	vl--;
-	strncpy (SDBKV_KEY (&s->tmpkv), k, SDB_KSZ - 1);
+	strncpy (sdbkv_key (&s->tmpkv), k, SDB_KSZ - 1);
 	s->tmpkv.key[SDB_KSZ - 1] = '\0';
-	free (SDBKV_VALUE (&s->tmpkv));
+	free (sdbkv_value (&s->tmpkv));
 	s->tmpkv.value = v;
 	s->tmpkv.value_len = vl;
 	return &s->tmpkv;
@@ -960,7 +919,7 @@ SDB_API bool sdb_expire_set(Sdb* s, const char *key, ut64 expire, ut32 cas) {
 	}
 	kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
 	if (found && kv) {
-		if (*SDBKV_VALUE (kv)) {
+		if (*sdbkv_value (kv)) {
 			if (!cas || cas == kv->cas) {
 				kv->expire = parse_expire (expire);
 				return true;
@@ -992,7 +951,7 @@ SDB_API bool sdb_expire_set(Sdb* s, const char *key, ut64 expire, ut32 cas) {
 SDB_API ut64 sdb_expire_get(Sdb* s, const char *key, ut32 *cas) {
 	bool found = false;
 	SdbKv *kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
-	if (found && kv && *SDBKV_VALUE (kv)) {
+	if (found && kv && *sdbkv_value (kv)) {
 		if (cas) {
 			*cas = kv->cas;
 		}

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -184,7 +184,7 @@ static void sdb_fini(Sdb* s, int donull) {
 	}
 	free (s->ndump);
 	free (s->dir);
-	free (s->tmpkv.value);
+	free (SDBKV_VALUE (&s->tmpkv));
 	s->tmpkv.value_len = 0;
 	if (donull) {
 		memset (s, 0, sizeof (Sdb));
@@ -226,7 +226,7 @@ SDB_API const char *sdb_const_get_len(Sdb* s, const char *key, int *vlen, ut32 *
 	/* search in memory */
 	kv = (SdbKv*) sdb_ht_find_kvp (s->ht, key, &found);
 	if (found) {
-		if (!kv->value || !*kv->value) {
+		if (!SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
 			return NULL;
 		}
 		if (s->timestamped && kv->expire) {
@@ -242,9 +242,9 @@ SDB_API const char *sdb_const_get_len(Sdb* s, const char *key, int *vlen, ut32 *
 			*cas = kv->cas;
 		}
 		if (vlen) {
-			*vlen = kv->value_len;
+			*vlen = SDBKV_VALUE_LEN (kv);
 		}
-		return kv->value;
+		return SDBKV_VALUE (kv);
 	}
 	/* search in disk */
 	if (s->fd == -1) {
@@ -354,7 +354,7 @@ SDB_API bool sdb_exists(Sdb* s, const char *key) {
 	}
 	kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
 	if (found && kv) {
-		return *kv->value;
+		return *SDBKV_VALUE (kv);
 	}
 	if (s->fd == -1) {
 		return false;
@@ -462,12 +462,12 @@ SDB_API bool sdb_kv_match(SdbKv *kv, const char *expr) {
 		char *e = strdup (expr);
 		char *ep = e + (eq - expr);
 		*ep++ = 0;
-		bool res = !*e || match (kv->key, e);
-		bool res2 = !*ep || match (kv->value, ep);
+		bool res = !*e || match (SDBKV_KEY (kv), e);
+		bool res2 = !*ep || match (SDBKV_VALUE (kv), ep);
 		free (e);
 		return res && res2;
 	}
-	return match (kv->key, expr);
+	return match (SDBKV_KEY (kv), expr);
 }
 
 SDB_API SdbKv* sdb_kv_new(const char *k, const char *v) {
@@ -489,21 +489,21 @@ SDB_API SdbKv* sdb_kv_new(const char *k, const char *v) {
 		free (kv);
 		return NULL;
 	}
-	kv->key = malloc (kv->key_len + 1);
-	if (!kv->key) {
+	kv->key = malloc (SDBKV_KEY_LEN (kv) + 1);
+	if (!SDBKV_KEY (kv)) {
 		free (kv);
 		return NULL;
 	}
-	memcpy (kv->key, k, kv->key_len + 1);
+	memcpy (SDBKV_KEY (kv), k, SDBKV_KEY_LEN (kv) + 1);
 	kv->value_len = vl;
 	if (vl) {
 		kv->value = malloc (vl + 1);
-		if (!kv->value) {
-			free (kv->key);
+		if (!SDBKV_VALUE (kv)) {
+			free (SDBKV_KEY (kv));
 			free (kv);
 			return NULL;
 		}
-		memcpy (kv->value, v, vl + 1);
+		memcpy (SDBKV_VALUE (kv), v, vl + 1);
 	} else {
 		kv->value = NULL;
 		kv->value_len = 0;
@@ -528,21 +528,21 @@ SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl) {
 	}
 	kv = R_NEW0 (SdbKv);
 	kv->key_len = kl;
-	kv->key = malloc (kv->key_len + 1);
-	if (!kv->key) {
+	kv->key = malloc (SDBKV_KEY_LEN (kv) + 1);
+	if (!SDBKV_KEY (kv)) {
 		free (kv);
 		return NULL;
 	}
-	memcpy (kv->key, k, kv->key_len + 1);
+	memcpy (SDBKV_KEY (kv), k, SDBKV_KEY_LEN (kv) + 1);
 	kv->value_len = vl;
 	if (vl) {
 		kv->value = malloc (vl + 1);
-		if (!kv->value) {
-			free (kv->key);
+		if (!SDBKV_VALUE (kv)) {
+			free (SDBKV_KEY (kv));
 			free (kv);
 			return NULL;
 		}
-		memcpy (kv->value, v, vl + 1);
+		memcpy (SDBKV_VALUE (kv), v, vl + 1);
 	} else {
 		kv->value = NULL;
 		kv->value_len = 0;
@@ -553,8 +553,8 @@ SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl) {
 }
 
 SDB_API void sdb_kv_free(SdbKv *kv) {
-	free (kv->key);
-	free (kv->value);
+	free (SDBKV_KEY (kv));
+	free (SDBKV_VALUE (kv));
 	R_FREE (kv);
 }
 
@@ -586,7 +586,7 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 	}
 	cdb_findstart (&s->db);
 	kv = sdb_ht_find_kvp (s->ht, key, &found);
-	if (found && kv->value) {
+	if (found && SDBKV_VALUE (kv)) {
 		if (cdb_findnext (&s->db, sdb_hash (key), key, klen)) {
 			if (cas && kv->cas != cas) {
 				if (owned) {
@@ -594,21 +594,21 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 				}
 				return 0;
 			}
-			if (vlen == kv->value_len && !strcmp (kv->value, val)) {
+			if (vlen == SDBKV_VALUE_LEN (kv) && !strcmp (SDBKV_VALUE (kv), val)) {
 				sdb_hook_call (s, key, val);
 				return kv->cas;
 			}
 			kv->cas = cas = nextcas ();
 			if (owned) {
 				kv->value_len = vlen;
-				free (kv->value);
+				free (SDBKV_VALUE (kv));
 				kv->value = val; // owned
 			} else {
-				if ((ut32)vlen > kv->value_len) {
-					free (kv->value);
+				if ((ut32)vlen > SDBKV_VALUE_LEN (kv)) {
+					free (SDBKV_VALUE (kv));
 					kv->value = malloc (vlen + 1);
 				}
-				memcpy (kv->value, val, vlen + 1);
+				memcpy (SDBKV_VALUE (kv), val, vlen + 1);
 				kv->value_len = vlen;
 			}
 		} else {
@@ -659,7 +659,7 @@ static int sdb_foreach_list_cb(void *user, const char *k, const char *v) {
 static int __cmp_asc(const void *a, const void *b) {
 	const SdbKv *ka = a;
 	const SdbKv *kb = b;
-	return strcmp (ka->key, kb->key);
+	return strcmp (SDBKV_KEY (ka), SDBKV_KEY (kb));
 }
 
 SDB_API SdbList *sdb_foreach_list(Sdb* s, bool sorted) {
@@ -731,12 +731,12 @@ static bool sdb_foreach_cdb(Sdb *s, SdbForeachCallback cb,
 		SdbKv *kv = sdb_ht_find_kvp (s->ht, k, &found);
 		if (found) {
 			free (v);
-			if (kv && kv->key && kv->value) {
-				if (!cb (user, kv->key, kv->value)) {
+			if (kv && SDBKV_KEY (kv) && SDBKV_VALUE (kv)) {
+				if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
 					return false;
 				}
 				if (cb2) {
-					cb2 (user, k, kv->value);
+					cb2 (user, k, SDBKV_VALUE (kv));
 				}
 			}
 		} else {
@@ -764,10 +764,10 @@ SDB_API bool sdb_foreach(Sdb* s, SdbForeachCallback cb, void *user) {
 	}
 #if INSERTORDER
 	ls_foreach (s->ht->list, iter, kv) {
-		if (!kv || !kv->value || !*kv->value) {
+		if (!kv || !SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
 			continue;
 		}
-		if (!cb (user, kv->key, kv->value)) {
+		if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
 			return sdb_foreach_end (s, false);
 		}
 	}
@@ -775,10 +775,10 @@ SDB_API bool sdb_foreach(Sdb* s, SdbForeachCallback cb, void *user) {
 	ut32 i;
 	for (i = 0; i < s->ht->size; i++) {
 		ls_foreach (s->ht->table[i], iter, kv) {
-			if (!kv || !kv->value || !*kv->value) {
+			if (!kv || !SDBKV_VALUE (kv) || !*SDBKV_VALUE (kv)) {
 				continue;
 			}
-			if (!cb (user, kv->key, kv->value)) {
+			if (!cb (user, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
 				return sdb_foreach_end (s, false);
 			}
 		}
@@ -821,10 +821,10 @@ SDB_API bool sdb_sync(Sdb* s) {
 	/* append new keyvalues */
 	for (i = 0; i < s->ht->size; ++i) {
 		ls_foreach (s->ht->table[i], iter, kv) {
-			if (kv->key && kv->value && *kv->value && !kv->expire) {
-				if (sdb_disk_insert (s, kv->key, kv->value)) {
+			if (SDBKV_KEY (kv) && SDBKV_VALUE (kv) && *SDBKV_VALUE (kv) && !kv->expire) {
+				if (sdb_disk_insert (s, SDBKV_KEY (kv), SDBKV_VALUE (kv))) {
 					it.n = iter->n;
-					sdb_remove (s, kv->key, 0);
+					sdb_remove (s, SDBKV_KEY (kv), 0);
 					iter = &it;
 				}
 			}
@@ -854,9 +854,9 @@ SDB_API SdbKv *sdb_dump_next(Sdb* s) {
 		return NULL;
 	}
 	vl--;
-	strncpy (s->tmpkv.key, k, SDB_KSZ - 1);
+	strncpy (SDBKV_KEY (&s->tmpkv), k, SDB_KSZ - 1);
 	s->tmpkv.key[SDB_KSZ - 1] = '\0';
-	free (s->tmpkv.value);
+	free (SDBKV_VALUE (&s->tmpkv));
 	s->tmpkv.value = v;
 	s->tmpkv.value_len = vl;
 	return &s->tmpkv;
@@ -960,7 +960,7 @@ SDB_API bool sdb_expire_set(Sdb* s, const char *key, ut64 expire, ut32 cas) {
 	}
 	kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
 	if (found && kv) {
-		if (*kv->value) {
+		if (*SDBKV_VALUE (kv)) {
 			if (!cas || cas == kv->cas) {
 				kv->expire = parse_expire (expire);
 				return true;
@@ -992,7 +992,7 @@ SDB_API bool sdb_expire_set(Sdb* s, const char *key, ut64 expire, ut32 cas) {
 SDB_API ut64 sdb_expire_get(Sdb* s, const char *key, ut32 *cas) {
 	bool found = false;
 	SdbKv *kv = (SdbKv*)sdb_ht_find_kvp (s->ht, key, &found);
-	if (found && kv && *kv->value) {
+	if (found && kv && *SDBKV_VALUE (kv)) {
 		if (cas) {
 			*cas = kv->cas;
 		}

--- a/src/sdbht.c
+++ b/src/sdbht.c
@@ -1,7 +1,7 @@
 #include "sdbht.h"
 
 SDB_API SdbHt* sdb_ht_new() {
-	return ht_new ((DupValue)strdup, (HtKvFreeFunc)sdb_kv_free, (CalcSize)strlen);
+	return ht_new ((DupValue)strdup, (HtKvFreeFunc)sdbkv_free, (CalcSize)strlen);
 }
 
 static bool sdb_ht_internal_insert(SdbHt* ht, const char* key,
@@ -13,8 +13,8 @@ static bool sdb_ht_internal_insert(SdbHt* ht, const char* key,
 	if (kvp) {
 		kvp->key = strdup ((void *)key);
 		kvp->value = strdup ((void *)value);
-		kvp->key_len = strlen (SDBKV_KEY (kvp));
-		kvp->value_len = strlen (SDBKV_VALUE (kvp));
+		kvp->key_len = strlen (sdbkv_key (kvp));
+		kvp->value_len = strlen (sdbkv_value (kvp));
 		kvp->expire = 0;
 		return ht_insert_kv (ht, (HtKv*)kvp, update);
 	}

--- a/src/sdbht.c
+++ b/src/sdbht.c
@@ -13,9 +13,9 @@ static bool sdb_ht_internal_insert(SdbHt* ht, const char* key,
 	if (kvp) {
 		kvp->key = strdup ((void *)key);
 		kvp->value = strdup ((void *)value);
-		kvp->key_len = strlen ((void *)kvp->key);
+		kvp->key_len = strlen (SDBKV_KEY (kvp));
+		kvp->value_len = strlen (SDBKV_VALUE (kvp));
 		kvp->expire = 0;
-		kvp->value_len = strlen ((void *)kvp->value);
 		return ht_insert_kv (ht, (HtKv*)kvp, update);
 	}
 	return false;

--- a/src/sdbht.h
+++ b/src/sdbht.h
@@ -14,6 +14,11 @@ typedef struct sdb_kv {
 	ut64 expire;
 } SdbKv;
 
+#define SDBKV_KEY(kv) ((kv)->key)
+#define SDBKV_VALUE(kv) ((kv)->value)
+#define SDBKV_KEY_LEN(kv) ((kv)->key_len)
+#define SDBKV_VALUE_LEN(kv) ((kv)->value_len)
+
 SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl);
 extern SdbKv* sdb_kv_new(const char *k, const char *v);
 extern ut32 sdb_hash(const char *key);

--- a/src/sdbht.h
+++ b/src/sdbht.h
@@ -14,15 +14,28 @@ typedef struct sdb_kv {
 	ut64 expire;
 } SdbKv;
 
-#define SDBKV_KEY(kv) ((kv)->key)
-#define SDBKV_VALUE(kv) ((kv)->value)
-#define SDBKV_KEY_LEN(kv) ((kv)->key_len)
-#define SDBKV_VALUE_LEN(kv) ((kv)->value_len)
+static inline char *sdbkv_key(const SdbKv *kv) {
+	return kv->key;
+}
 
-SDB_API SdbKv* sdb_kv_new2(const char *k, int kl, const char *v, int vl);
-extern SdbKv* sdb_kv_new(const char *k, const char *v);
+static inline char *sdbkv_value(const SdbKv *kv) {
+	return kv->value;
+}
+
+static inline ut32 sdbkv_key_len(const SdbKv *kv) {
+	return kv->key_len;
+}
+
+static inline ut32 sdbkv_value_len(const SdbKv *kv) {
+	return kv->value_len;
+}
+
+extern void sdbkv_free(SdbKv *kv);
+
+SDB_API SdbKv* sdbkv_new2(const char *k, int kl, const char *v, int vl);
+extern SdbKv* sdbkv_new(const char *k, const char *v);
+
 extern ut32 sdb_hash(const char *key);
-extern void sdb_kv_free(SdbKv *kv);
 
 SDB_API SdbHt* sdb_ht_new(void);
 // Destroy a hashtable and all of its entries.

--- a/src/sdbht.h
+++ b/src/sdbht.h
@@ -30,10 +30,9 @@ static inline ut32 sdbkv_value_len(const SdbKv *kv) {
 	return kv->value_len;
 }
 
-extern void sdbkv_free(SdbKv *kv);
-
 SDB_API SdbKv* sdbkv_new2(const char *k, int kl, const char *v, int vl);
 extern SdbKv* sdbkv_new(const char *k, const char *v);
+extern void sdbkv_free(SdbKv *kv);
 
 extern ut32 sdb_hash(const char *key);
 

--- a/test/unit/test_hash.c
+++ b/test/unit/test_hash.c
@@ -51,11 +51,11 @@ bool test_ht_delete(void) {
 
 bool test_ht_insert_kvp(void) {
 	SdbHt *ht = sdb_ht_new ();
-	SdbKv *kv = sdb_kv_new ("AAAA", "vAAAA");
+	SdbKv *kv = sdbkv_new ("AAAA", "vAAAA");
 	mu_assert ("AAAA shouldn't exist", !sdb_ht_find_kvp (ht, "AAAA", NULL));
 	sdb_ht_insert_kvp (ht, kv, false);
 	mu_assert ("AAAA should exist", sdb_ht_find_kvp (ht, "AAAA", NULL));
-	SdbKv *kv2 = sdb_kv_new ("AAAA", "vNEWAAAA");
+	SdbKv *kv2 = sdbkv_new ("AAAA", "vNEWAAAA");
 	mu_assert ("AAAA shouldn't be replaced", !sdb_ht_insert_kvp (ht, kv2, false));
 	mu_assert ("AAAA should be replaced", sdb_ht_insert_kvp (ht, kv2, true));
 
@@ -118,7 +118,7 @@ bool test_ht_grow(void) {
 
 bool test_ht_kvp(void) {
 	SdbHt *ht = sdb_ht_new ();
-	SdbKv *kvp = sdb_kv_new ("AAAA", "vAAAA");
+	SdbKv *kvp = sdbkv_new ("AAAA", "vAAAA");
 
 	mu_assert_eq (kvp->key_len, 4, "key_len should be 4");
 	mu_assert_eq (kvp->value_len, 5, "value_len should be 5");


### PR DESCRIPTION
~~This PR is based on https://github.com/radare/sdb/pull/158 .~~

~~The only difference is the last commits.~~ The commit introduces helper macros in the sdbht.h file to access SdbKv->key/value/key_len/value_len since they are fields of the "base structure" HtKv. In another PR i'm going to change those fields, so I want to introduce these helpers to make those change easier. 