### PR TITLE
Fix b64_* for Solaris

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -10,7 +10,7 @@
 static const char cb64[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char cd64[]="|$$$}rstuvwxyz{$$$$$$$>?@ABCDEFGHIJKLMNOPQRSTUVW$$$$$$XYZ[\\]^_`abcdefghijklmnopq";
 
-static void b64_encode(const ut8 in[3], char out[4], int len) {
+static void sdb_b64_encode(const ut8 in[3], char out[4], int len) {
 	if (len < 1) {
 		return;
 	}
@@ -20,7 +20,7 @@ static void b64_encode(const ut8 in[3], char out[4], int len) {
 	out[3] = (len > 2 ? cb64[ in[2] & 0x3f ] : '=');
 }
 
-static int b64_decode(const char in[4], ut8 out[3]) {
+static int sdb_b64_decode(const char in[4], ut8 out[3]) {
 	int len = 3;
 	ut8 i, v[4] = {0};
 	for (i = 0; i < 4; i++) {
@@ -43,7 +43,7 @@ static int b64_decode(const char in[4], ut8 out[3]) {
 SDB_API void sdb_encode_raw(char *bout, const ut8 *bin, int len) {
 	int in, out;
 	for (in = out = 0; in < len; in += 3,out+=4) {
-		b64_encode (bin + in, bout + out,
+		sdb_b64_encode (bin + in, bout + out,
 			(len - in) > 3? 3: (len - in));
 	}
 	bout[out] = 0;
@@ -52,7 +52,7 @@ SDB_API void sdb_encode_raw(char *bout, const ut8 *bin, int len) {
 SDB_API int sdb_decode_raw(ut8 *bout, const char *bin, int len) {
 	int in, out, ret;
 	for (in = out = 0; in < len; in += 4) {
-		ret = b64_decode (bin + in, bout + out);
+		ret = sdb_b64_decode (bin + in, bout + out);
 		if (ret < 1) {
 			break;
 		}


### PR DESCRIPTION
Solaris has its own b64_encode and b64_decode functions, which the ones here can conflict with:
```
Standard C Library Functions                                    b64_encode(3C)

NAME
       b64_encode,  b64_decode,  b32_encode,  b32_decode - encode and decode a
       string in base64 or base32

SYNOPSIS
       #include <string.h>

       ssize_t b64_encode(char restrict *outbuf, size_t outbufsz,
                const void restrict *inbuf, size_t inbufsz,
                const char *alphabet, uint64_t flags);

       ssize_t b64_decode(void *outbuf, size_t outbufsz,
                const char *inbuf, const char *alphabet, uint64_t flags);

```