### PR TITLE
meson: Do not use glob with Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,22 @@
-project('sdb', 'c', meson_version: '>=0.46.0')
-py3_exe = import('python3').find_python()
+project('sdb', 'c', meson_version: '>=0.47.0')
+py3_exe = import('python').find_installation('python3')
+pkgconfig_mod = import('pkgconfig')
 
-version_cmd = 'import sys; l=open("config.mk").read().split("\\n"); print(next(filter(lambda x: "SDBVER=" in x, l)).split("=")[1])'
-sdb_version = run_command(py3_exe, '-c', version_cmd)
-if sdb_version.returncode() == 0
-  sdb_version = sdb_version.stdout().strip()
+version_cmd = '''from sys import argv
+with open(argv[1]) as fd:
+  for line in fd:
+    if line.startswith('SDBVER='):
+      version_tuple = line.split('=')[1]
+      print(version_tuple)
+      break
+'''
+sdb_version = '0.0.1'
+config_mk = files('config.mk')[0]
+r = run_command(py3_exe, '-c', version_cmd, config_mk)
+if r.returncode() == 0
+  sdb_version = r.stdout().strip()
 else
-  sdb_version = '0.0.1'
+  warning('Cannot determine SDB version')
 endif
 message('SDB version = ' + sdb_version)
 sdb_libversion = host_machine.system() == 'windows' ? '' : sdb_version
@@ -17,12 +27,15 @@ if host_machine.system() == 'windows'
 endif
 
 # Create sdb_version.h
-sdb_version_path = join_paths(meson.current_build_dir(), 'sdb_version.h')
-run_command(py3_exe, '-c', 'with open("@0@", "w") as f: f.write("#define SDB_VERSION \"@1@\"")'.format(sdb_version_path, sdb_version))
+conf_data = configuration_data()
+conf_data.set_quoted('SDB_VERSION', sdb_version, description : 'From config.mk')
+configure_file(
+  output : 'sdb_version.h',
+  configuration : conf_data,
+  install_dir : join_paths(get_option('includedir'), 'sdb')
+)
 
-glob_cmd = [py3_exe, '-c', 'from sys import argv; print(";".join(__import__("glob").glob(argv[1])))']
-
-files = [
+libsdb_sources = [
   'src/array.c',
   'src/base64.c',
   'src/buffer.c',
@@ -57,7 +70,7 @@ sdb_inc = [
   include_directories(['.', 'src'])
 ]
 
-libsdb = both_libraries('sdb', files,
+libsdb = both_libraries('sdb', libsdb_sources,
   include_directories: sdb_inc,
   implicit_include_directories: false,
   soversion: sdb_libversion,
@@ -70,7 +83,21 @@ if meson.is_subproject()
     include_directories: sdb_inc
   )
 else
-  include_files = run_command(glob_cmd + ['src/*.h']).stdout().strip().split(';') + [sdb_version_path]
+  include_files = [
+    'src/buffer.h',
+    'src/cdb.h',
+    'src/cdb_make.h',
+    'src/config.h',
+    'src/dict.h',
+    'src/ht_inc.h',
+    'src/ht_pp.h',
+    'src/ht_up.h',
+    'src/ht_uu.h',
+    'src/ls.h',
+    'src/sdb.h',
+    'src/sdbht.h',
+    'src/types.h'
+  ]
   install_headers(include_files, subdir: 'sdb')
 endif
 
@@ -87,22 +114,18 @@ sdb_exe = executable('sdb', 'src/main.c',
   implicit_include_directories: false
 )
 
-sdb_gen_cmd = [
-  py3_exe,
-  '-c',
-  'from sys import argv; __import__("os").system("@0@ %s = <%s" % (argv[1], argv[2]))'.format(sdb_exe.full_path()),
-  '@OUTPUT@',
-  '@INPUT@'
-]
+if not meson.is_subproject()
+  install_man(['src/sdb.1'])
+endif
 
-pkgconfig_mod = import('pkgconfig')
 pkgconfig_mod.generate(
-  libraries: [libsdb.get_shared_lib()],
-  subdirs: ['sdb', '.'],
-  version: sdb_version,
   name: 'sdb',
   filebase: 'sdb',
-  description: 'Simple DataBase'
+  libraries: [libsdb.get_shared_lib()],
+  description: 'Simple DataBase',
+  subdirs: ['sdb', '.'],
+  version: sdb_version,
+  url: 'https://github.com/radare/sdb'
 )
 
 make_test_executable = find_program('make')


### PR DESCRIPTION
*Explicit is better than implicit*.
This PR:
 * Use Meson 0.47.0 to use install_man
 * Prefer using configuration() than manually generating header file
 * Install sdb man file