### PR TITLE
Add benchmark suites to meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,10 +128,16 @@ pkgconfig_mod.generate(
   url: 'https://github.com/radare/sdb'
 )
 
-make_test_executable = find_program('make', required: false)
-test('run tests', make_test_executable,
-  args: 'test',
-  env: ['BASEDIR=' + meson.current_build_dir()],
-  workdir: join_paths(meson.current_build_dir(), '..'),
-  depends: [sdb_exe, libsdb]
-)
+if not meson.is_subproject()
+  make_exe = find_program('make', required: false)
+  if make_exe.found()
+    test('run tests', make_exe,
+      args: 'test',
+      env: ['BASEDIR=' + meson.current_build_dir()],
+      workdir: join_paths(meson.current_build_dir(), '..'),
+      depends: [sdb_exe, libsdb]
+    )
+  endif
+
+  subdir('test/bench')
+endif

--- a/test/bench/meson.build
+++ b/test/bench/meson.build
@@ -1,0 +1,17 @@
+tests = [
+  'array',
+  'new',
+  'reset',
+  'set',
+  'stack',
+  'sync'
+]
+
+foreach test : tests
+  name = 'bench-' + test
+  exe = executable(name, name + '.c',
+    include_directories: sdb_inc,
+    link_with: libsdb.get_static_lib()
+  )
+  benchmark(name, exe)
+endforeach

--- a/test/bench/prof.c
+++ b/test/bench/prof.c
@@ -1,13 +1,39 @@
 /* radare - LGPL - Copyright 2009-2012 - pancake */
 
 #define R_API
+#define R_ABS(x) (((x)<0)?-(x):(x))
+
+#ifdef _MSC_VER
+
+#include "Windows.h"
+
+typedef struct r_prof_t {
+	LARGE_INTEGER begin;
+	double result;
+} RProfile;
+
+R_API void r_prof_start(struct r_prof_t *p) {
+	p->result = 0.0;
+	QueryPerformanceCounter (&p->begin);
+}
+
+R_API double r_prof_end(struct r_prof_t *p) {
+	LARGE_INTEGER end, freq, diff;
+	QueryPerformanceCounter (&end);
+	QueryPerformanceFrequency (&freq);
+	diff.QuadPart = end.QuadPart - p->begin.QuadPart;
+	p->result = R_ABS ((double)diff.QuadPart / freq.QuadPart);
+	return R_ABS (diff.QuadPart < 0);
+}
+
+#else
+
 #include <sys/time.h>
 
 typedef struct r_prof_t {
         struct timeval begin;
         double result;
 } RProfile;
-#define R_ABS(x) (((x)<0)?-(x):(x))
 
 typedef struct timeval tv;
 
@@ -49,3 +75,5 @@ R_API double r_prof_end(struct r_prof_t *p) {
 		+ ((double)diff.tv_usec / 1000000.)));
 	return R_ABS (sign);
 }
+
+#endif


### PR DESCRIPTION
Example of using: `meson test --benchmark --verbose -C build`