### PR TITLE
Fix crash on Windows due to closing already closed file descriptor

### DIFF
--- a/src/sdb.c
+++ b/src/sdb.c
@@ -428,6 +428,10 @@ SDB_API int sdb_open(Sdb *s, const char *file) {
 SDB_API void sdb_close(Sdb *s) {
 	if (s) {
 		if (s->fd != -1) {
+			if (s->db.fd != -1 && s->db.fd == s->fd) {
+				/* close db fd as well */
+				s->db.fd = -1;
+			}
 			close (s->fd);
 			s->fd = -1;
 		}


### PR DESCRIPTION
This  PR fixes closing of a file descriptor which is already closed (causes `abort()` on windows) so radare2 just crashed before.

Sample to reproduce is attached in an archive, password `infected`
[CDPLAYER.EXE.zip](https://github.com/radare/sdb/files/2963751/CDPLAYER.EXE.zip)

How to reproduce a crash:

- unpack and open provided file with radare2 like `radare2.exe CDPLAYER.EXE.bad` on **Windows**
- crash

After fix it should smoothly open such file:

![image](https://user-images.githubusercontent.com/14978853/54316024-c6208b80-45f0-11e9-88f3-bfe75fcb4763.png)

